### PR TITLE
Convert an emoji img tag to an emoji notation although its alt is emoji code

### DIFF
--- a/lib/slacken/document_component.rb
+++ b/lib/slacken/document_component.rb
@@ -68,5 +68,11 @@ module Slacken
         RenderElement.new(type, children.map(&:produce_element), attrs)
       end
     end
+
+    def ==(another)
+      type == another.type &&
+      attrs_comp = attrs.sort == another.attrs.sort &&
+      children == another.children
+    end
   end
 end

--- a/lib/slacken/filters/stringfy_emoji.rb
+++ b/lib/slacken/filters/stringfy_emoji.rb
@@ -3,7 +3,9 @@ module Slacken::Filters
   class StringfyEmoji < Slacken::Filter
     def call(component)
       if emoji_img_tag?(component)
-        component.class.new(:emoji, [], content: component.attrs[:alt])
+        emoji_code = component.attrs[:alt]
+        emoji_code = $~[:emoji_code] if emoji_code.match(/^:(?<emoji_code>.+):$/)
+        component.class.new(:emoji, [], content: emoji_code)
       else
         component.derive(component.children.map(&method(:call)))
       end

--- a/lib/slacken/node_type.rb
+++ b/lib/slacken/node_type.rb
@@ -50,5 +50,9 @@ module Slacken
     def allowed_in_link?
       member_of?(%i(b strong i em wrapper span).concat(text_types))
     end
+
+    def ==(another)
+      name == another.name
+    end
   end
 end

--- a/lib/slacken/node_type.rb
+++ b/lib/slacken/node_type.rb
@@ -32,23 +32,23 @@ module Slacken
     end
 
     def allowed_in_list?
-      member_of?(%i(code b strong i em wrapper div indent span ol ul dl li dd dt).concat(text_types))
+      member_of?(%i(emoji code b strong i em wrapper div indent span ol ul dl li dd dt).concat(text_types))
     end
 
     def allowed_as_list_item?
-      member_of?(%i(code b strong i em wrapper span).concat(text_types))
+      member_of?(%i(emoji code b strong i em wrapper span).concat(text_types))
     end
 
     def allowed_in_headline?
-      member_of?(%i(i em wrapper span).concat(text_types))
+      member_of?(%i(emoji i em wrapper span).concat(text_types))
     end
 
     def allowed_in_table?
-      member_of?(%i(code b strong i em wrapper span thead tbody tr th td).concat(text_types))
+      member_of?(%i(emoji code b strong i em wrapper span thead tbody tr th td).concat(text_types))
     end
 
     def allowed_in_link?
-      member_of?(%i(b strong i em wrapper span).concat(text_types))
+      member_of?(%i(emoji b strong i em wrapper span).concat(text_types))
     end
 
     def ==(another)

--- a/lib/slacken/render_element.rb
+++ b/lib/slacken/render_element.rb
@@ -19,7 +19,7 @@ module Slacken
       when :text
         attrs[:content]
       when :emoji
-        deco "#{attrs[:content]}"
+        deco ":#{attrs[:content].strip}:"
       when :checkbox
         deco (attrs[:checked] ? '[x]' : '[ ]')
       when :b, :strong

--- a/spec/slacken/document_component_spec.rb
+++ b/spec/slacken/document_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Slacken::DocumentComponent do
+describe Slacken::DocumentComponent, dsl: true do
   let(:document_component) { described_class.build_by_html(source) }
   # If you change the behavior, you should run `scripts/update_markup_fixture.rb`
   # to update fixture file.
@@ -14,6 +14,90 @@ describe Slacken::DocumentComponent do
         let(:filter) { klass.new }
         it { is_expected.to satisfy(&filter.method(:valid?)) }
       end
+    end
+  end
+
+  describe '#==' do
+    subject { component1 == component2 }
+
+    describe 'when the two are the same object' do
+      let(:component1) do
+        c(:ul,
+          c(:li,
+            text('header'),
+            c(:img, class: 'emoji', alt: 'emoji_code'),
+            c(:indent,
+              c(:h1, text('hoge')))))
+      end
+      let(:component2) do
+        component1
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    describe 'when the two have same structure' do
+      let(:component1) do
+        c(:ul,
+          c(:li,
+            text('header'),
+            c(:img, class: 'emoji', alt: 'emoji_code'),
+            c(:indent,
+              c(:h1, text('hoge')))))
+      end
+      let(:component2) do
+        c(:ul,
+          c(:li,
+            text('header'),
+            c(:img, class: 'emoji', alt: 'emoji_code'),
+            c(:indent,
+              c(:h1, text('hoge')))))
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    describe "when the two's children are different " do
+      let(:component1) do
+        c(:ul,
+          c(:li,
+            text('header'),
+            c(:img, class: 'emoji', alt: 'emoji_code'),
+            c(:indent,
+              c(:h1, text('hoge')))))
+      end
+      let(:component2) do
+        c(:ul,
+          c(:li,
+            c(:img, class: 'emoji', alt: 'emoji_code'),
+            text('footer'),
+            c(:indent,
+              c(:h1, text('hoge')))))
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    describe "when the two's attributes are different " do
+      let(:component1) do
+        c(:img, class: 'emoji', alt: 'hoge')
+      end
+      let(:component2) do
+        c(:img, class: 'emoji', alt: 'fuga')
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    describe "when the two's types are different " do
+      let(:component1) do
+        c(:img, class: 'emoji', alt: 'hoge')
+      end
+      let(:component2) do
+        c(:a, class: 'emoji', alt: 'fuga')
+      end
+
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/slacken/filters/stringfy_emoji_spec.rb
+++ b/spec/slacken/filters/stringfy_emoji_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Slacken::Filters::StringfyEmoji, dsl: true do
+  describe '#call' do
+    subject { described_class.new.call(component) }
+
+    context "when the img tag's alt is ':emoji_code:'" do
+      let(:component) do
+        c(:img, class: 'emoji', alt: ':emoji_code:')
+      end
+
+      it { is_expected.to eq(c(:emoji, content: 'emoji_code')) }
+    end
+
+    context "when the img tag's alt is 'emoji_code'" do
+      let(:component) do
+        c(:img, class: 'emoji', alt: 'emoji_code')
+      end
+
+      it { is_expected.to eq(c(:emoji, content: 'emoji_code')) }
+    end
+  end
+end

--- a/spec/slacken_spec.rb
+++ b/spec/slacken_spec.rb
@@ -61,19 +61,38 @@ describe Slacken do
     end
 
     context 'when emoji img is given' do
-      let(:source) do
-        <<-EOS.unindent
-          <p>
-          hello
-          <img  class="emoji" title=":eyes:" alt=":eyes:" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle">
-          world
-          <img class="emoji" title=":bowtie:" alt=":bowtie:" src="https://cdn.qiita.com/emoji/bowtie.png" height="20" width="20" align="absmiddle">
-          </p>
-        EOS
+      context 'and its alt is written with emoji notation' do
+        let(:source) do
+          <<-EOS.unindent
+            <p>
+            hello
+            <img  class="emoji" title=":eyes:" alt=":eyes:" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle">
+            world
+            <img class="emoji" title=":bowtie:" alt=":bowtie:" src="https://cdn.qiita.com/emoji/bowtie.png" height="20" width="20" align="absmiddle">
+            </p>
+          EOS
+        end
+
+        it 'replaces img elements with corresponding emoji notation' do
+          should eq 'hello :eyes: world :bowtie:'
+        end
       end
 
-      it 'replaces img elements with corresponding emoji notation' do
-        should eq 'hello :eyes: world :bowtie:'
+      context 'and its alt is emoji code' do
+        let(:source) do
+          <<-EOS.unindent
+            <p>
+            hello
+            <img  class="emoji" title="eyes" alt="eyes" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle">
+            world
+            <img class="emoji" title="bowtie" alt="bowtie" src="https://cdn.qiita.com/emoji/bowtie.png" height="20" width="20" align="absmiddle">
+            </p>
+          EOS
+        end
+
+        it 'replaces img elements with corresponding emoji notation' do
+          should eq 'hello :eyes: world :bowtie:'
+        end
       end
     end
 

--- a/spec/slacken_spec.rb
+++ b/spec/slacken_spec.rb
@@ -18,6 +18,20 @@ describe Slacken do
       it 'wraps inner text with "*"' do
         should eq '*heading _italic_ bold*'
       end
+
+      context 'when the h1 tag contains an emoji' do
+        let(:source) do
+          <<-EOS.unindent
+            <h1>
+              heading<img class="emoji" title=":eyes:" alt=":eyes:" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle">
+            </h1>
+          EOS
+        end
+
+        it 'wraps inner text with "*"' do
+          should eq '*heading :eyes:*'
+        end
+      end
     end
 
     context 'when p is given' do
@@ -93,6 +107,31 @@ describe Slacken do
         it 'replaces img elements with corresponding emoji notation' do
           should eq 'hello :eyes: world :bowtie:'
         end
+      end
+    end
+
+    context 'when li elements which contain emojis are given' do
+      let(:source) do
+        <<-EOS.unindent
+          <ul>
+          <li>リスト1</li>
+          <li>リスト2<img class="emoji" title=":bowtie:" alt=":bowtie:" src="https://cdn.qiita.com/emoji/bowtie.png" height="20" width="20" align="absmiddle"></li>
+          <li>リスト3
+          <ul>
+          <li>リスト3-1<img class="emoji" title=":eyes:" alt=":eyes:" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle"></li>
+          </ul>
+          </li>
+          </ul>
+        EOS
+      end
+
+      it 'converts to list notation' do
+        should eq <<-EOS.unindent.chomp
+        • リスト1
+        • リスト2 :bowtie:
+        • リスト3
+            • リスト3-1 :eyes:
+        EOS
       end
     end
 
@@ -252,6 +291,42 @@ describe Slacken do
       end
     end
 
+    context 'when table which contains emoji is given' do
+      let(:source) do
+        <<-EOS.unindent
+          <table>
+          <thead>
+          <tr>
+          <th>Header1<img class="emoji" title=":eyes:" alt=":eyes:" src="https://cdn.qiita.com/emoji/unicode/1f440.png" height="20" width="20" align="absmiddle"></th>
+          <th>Header2</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>Cell1</td>
+          <td>Cell2</td>
+          </tr>
+          <tr>
+          <td>hello</td>
+          <td>world</td>
+          </tr>
+          </tbody>
+          </table>
+        EOS
+      end
+
+      it 'converts html to table notation' do
+        should eq <<-EOS.unindent.chomp
+          +--------------+-------+
+          |Header1 :eyes:|Header2|
+          +--------------+-------+
+          |Cell1         |Cell2  |
+          |hello         |world  |
+          +--------------+-------+
+        EOS
+      end
+    end
+
     context 'when table with empty td is given' do
       let(:source) do
         <<-EOS.unindent
@@ -359,6 +434,15 @@ describe Slacken do
 
       it 'ignores the link' do
         should eq "<#{src}|#{alt}>"
+      end
+    end
+
+    context 'when emoji in a is given' do
+      let(:source) { "<p><a href='#{src}'><img class='emoji' title=':bowtie:' alt=':bowtie:' src='https://cdn.qiita.com/emoji/bowtie.png' height='20' width='20' align='absmiddle'></a></p>" }
+      let(:src) { 'http://cdn.qiita.com/logo.png' }
+
+      it 'converts emoji in the link' do
+        should eq "<#{src}|:bowtie:>"
       end
     end
 


### PR DESCRIPTION
Converts emoji img tags to emoji notations whether the alt attribute of each emoji img tag is emoji notation (e.g. `:dog:`) or emoji code (which means the string between colons of emoji notation. e.g `dog` of `:dog:`).
(For now, emoji img tags whose alt are emoji code are not converted.)

## Additional Changes
This PR redefines `==` DocumentComponent and NodeType methods in order to compare structures of instances in tests.