### PR TITLE
Add test workflow to test with recent Ruby versions (3.2, 3.3, 3.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rspec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.2", "3.3", "3.4"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm: 2.2
-script: bundle exec rake spec

--- a/slacken.gemspec
+++ b/slacken.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_development_dependency 'bundler', '~> 1.0'
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rdoc', '~> 3.0'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
# What

Close https://github.com/increments/slacken/issues/13
Close https://github.com/increments/slacken/issues/14

- Add test workflow on github action
- Remove bundler version limitation

# Why

- https://github.com/increments/slacken/actions/runs/15269991855/job/42943136528

```
Because the current Bundler version (2.4.19) does not satisfy bundler ~> 1.0
  and Gemfile depends on bundler ~> 1.0,
  version solving has failed.
```

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
